### PR TITLE
Fixes incorrect modules usage: including outside the global module fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Provides the `add_module_library` CMake function that is a wrapper around `add_l
 
 `hello.cc`:
 ```c++
-export module hello;
+module;
 
 #include <cstdio>
+
+export module hello;
 
 export void hello() { std::printf("Hello, modules!\n"); }
 ```

--- a/hello.cc
+++ b/hello.cc
@@ -1,6 +1,9 @@
+module;
+
+#include <cstdio>
+
 export module hello;
 
 #include "hello.h"
-#include <cstdio>
 
 export void hello() { std::printf("Hello, modules!\n"); }


### PR DESCRIPTION
Includes from other libraries (in particular the standard library ) should only appear in the global-module-fragment of the module interface of a module (that's long to say). The initial code was basically taking ownership of the content of the included file, while this version does not.