### PR TITLE
Clang: fix CMAKE_CXX_STANDARD 23/26

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
         # https://github.com/actions/virtual-environments.
         os: [ubuntu-22.04]
         compiler: ["g++-12", "g++-13", "clang++-14", "clang++-15", "clang++-16"]
-        standard: [20]
+        standard: [20, 23]
         build_type: [Debug]
         include:
           - cxx: g++-12

--- a/modules.cmake
+++ b/modules.cmake
@@ -31,10 +31,14 @@ function(add_module_library name)
     target_compile_options(${name} PUBLIC -fmodules-ts)
   endif ()
 
-  # `std` is affected by CMake options and may be higher than C++20.
-  get_target_property(std ${name} CXX_STANDARD)
-
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # `std` is affected by CMake options and may be higher than C++20.
+    # Clang does not support c++23/c++26 names, so replace it with 2b
+    get_target_property(std ${name} CXX_STANDARD)
+    if(std GREATER 20)
+        set(std 2b)
+    endif()
+
     set(pcms)
     foreach (src ${sources})
       get_filename_component(pcm ${src} NAME_WE)


### PR DESCRIPTION
Part of https://github.com/vitaut/modules/pull/2

* replace standard greater than C++20 with 2b for Clang compiler
* reduce scope for `std` variable to clang since GCC and MSVC does not use it