### PR TITLE
Detect module support by testing its compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project(HELLO CXX)
 
 include(modules.cmake)
 
+modules_get_latest_cxx_std(std_latest_ver)
+message("std_latest_ver=${std_latest_ver}")
+
+modules_supported(cxx_modules)
+message("cxx_modules=${cxx_modules}")
+
 add_module_library(hello hello.cc)
 target_include_directories(hello PRIVATE include)
 

--- a/modules.cmake
+++ b/modules.cmake
@@ -124,8 +124,13 @@ function(add_module_library name)
   add_library(${name})
   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
 
-  if (NOT ${${AML_IF}})
-    # Create a non-modular library.
+  # Detect module support in case it was not explicitly defined
+  if(NOT DEFINED AML_IF)
+    modules_supported(AML_IF)
+  endif()
+
+  # Add fallback sources to the target in case modules are not supported or fallback was explicitly selected
+  if (NOT ${AML_IF})
     target_sources(${name} PRIVATE ${AML_FALLBACK})
     return()
   endif ()

--- a/modules.cmake
+++ b/modules.cmake
@@ -43,6 +43,29 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif ()
 
 
+
+# Receives latest available C++ standard version
+#
+# Usage:
+#   modules_get_latest_cxx_std(<variable_name>)
+#   if(<variable_name> GREATER 17)
+#      ...
+#   endif()
+function(modules_get_latest_cxx_std result)
+  # assume that 98 will be supported even with a broken feature detection
+  set(std_version 98)
+
+  # iterate over features and use the latest one (CMake always sorts features from the oldest to the newest)
+  foreach(compiler_feature ${CMAKE_CXX_COMPILE_FEATURES})
+    if(compiler_feature MATCHES "cxx_std_(.*)")
+      set(std_version ${CMAKE_MATCH_1})
+    endif()
+  endforeach()
+
+  set(${result} ${std_version} PARENT_SCOPE)
+endfunction()
+
+
 # Adds a library compiled with C++20 module support.
 # `enabled` is a CMake variables that specifies if modules are enabled.
 # If modules are disabled `add_module_library` falls back to creating a


### PR DESCRIPTION
Part of https://github.com/vitaut/modules/pull/2, but improved

* added function `modules_get_latest_cxx()` to get the latest standard version
* added function `modules_is_supported()` to build a simple module to determine actual module support
* use fallback sources in `add_module_library()` in case the check fails