### PR TITLE
CMake, CI: fix GCC

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,16 +12,14 @@ jobs:
       matrix:
         # https://github.com/actions/virtual-environments.
         os: [ubuntu-22.04]
-        compiler: ["g++-12", "g++-13", "clang++-14", "clang++-15", "clang++-16"]
+        cxx: ["g++-11", "g++-12", "clang++-15", "clang++-16"]
         standard: [20, 23]
         build_type: [Debug]
         include:
+          - cxx: g++-11
+            install: sudo apt install g++-11
           - cxx: g++-12
             install: sudo apt install g++-12
-          - cxx: g++-13
-            install: sudo apt install g++-13
-          - cxx: clang++-14
-            install: sudo apt install clang-14
           - cxx: clang++-15
             source: "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
             install: sudo apt install clang-15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,20 @@
 cmake_minimum_required(VERSION 3.11)
 project(HELLO CXX)
 
+# Include module library
 include(modules.cmake)
 
+# Display debug info
 modules_get_latest_cxx_std(std_latest_ver)
-message("std_latest_ver=${std_latest_ver}")
-
 modules_supported(cxx_modules)
-message("cxx_modules=${cxx_modules}")
+message(STATUS "C++ standard targeted  = ${CMAKE_CXX_STANDARD}")
+message(STATUS "C++ standard supported = ${std_latest_ver}")
+message(STATUS "C++ modules supported  = ${cxx_modules}")
 
+# Module library
 add_module_library(hello hello.cc)
 target_include_directories(hello PRIVATE include)
 
+# Demo application
 add_executable(main main.cc)
 target_link_libraries(main hello)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Simple C++20 module support for CMake
 
 [![](https://github.com/vitaut/modules/workflows/linux/badge.svg)](https://github.com/vitaut/modules/actions?query=workflow%3Alinux)
+[![](https://github.com/vitaut/modules/workflows/windows/badge.svg)](https://github.com/vitaut/modules/actions?query=workflow%3Awindows)
 
-Provides the `add_module_library` CMake function that is a wrapper around `add_library` with additional module-specific rules. Currently supports clang 15+ and gcc 12+ and can fallback to a non-modular library for compatibility.
+Provides the `add_module_library` CMake function that is a wrapper around `add_library` with additional module-specific rules. 
+
+This module currently supports:
+* Clang 15+ 
+* GCC 11+
+* MSVC 19.28+
+
+This module can also fallback to a non-modular library for compatibility.
 
 Projects using `add_module_library`:
 

--- a/modules.cmake
+++ b/modules.cmake
@@ -89,6 +89,8 @@ function(modules_supported result)
     set(compiler_flags "")
     if (MSVC)
       set(compiler_flags "/interface")
+    elseif (CMAKE_COMPILER_IS_GNUCXX)
+      set(compiler_flags "-fmodules-ts")
     endif ()
 
     # Try to build it.


### PR DESCRIPTION
connected with https://github.com/vitaut/modules/issues/10

* fix modules support detection for GCC (previously it was always false on GCC)
* fix CI (it was always Clang 16 on Linux)
* add compiler info to the demo output
* update list of supported compiler in readme