### PR TITLE
Do not force C++20 in case CMAKE_CXX_STANDARD defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,12 @@ include(modules.cmake)
 # Display debug info
 modules_get_latest_cxx_std(std_latest_ver)
 modules_supported(cxx_modules)
-message(STATUS "C++ standard targeted  = ${CMAKE_CXX_STANDARD}")
-message(STATUS "C++ standard supported = ${std_latest_ver}")
-message(STATUS "C++ modules supported  = ${cxx_modules}")
+modules_supported(cxx_modules_latest STANDARD ${std_latest_ver})
+message(STATUS "C++ target standard  = ${CMAKE_CXX_STANDARD}")
+message(STATUS "    modules support  = ${cxx_modules}")
+message(STATUS "")
+message(STATUS "C++ latest standard  = ${std_latest_ver}")
+message(STATUS "    modules support  = ${cxx_modules_latest}")
 
 # Module library
 add_module_library(hello hello.cc)

--- a/modules.cmake
+++ b/modules.cmake
@@ -69,16 +69,25 @@ endfunction()
 # Checks that the compiler supports C++20 modules.
 #
 # Usage:
-#   modules_supported(<variable_name>)
+#   modules_supported(<variable_name> [STANDARD standard_ver])
 #   if (<variable_name>)
 #     ...
 #   endif ()
 function(modules_supported result)
+  cmake_parse_arguments(MS "" "STANDARD" "" ${ARGN})
+
   set(${result} FALSE PARENT_SCOPE)
 
   # Check the standard version.
-  modules_get_latest_cxx_std(latest_standard)
-  if(latest_standard GREATER_EQUAL 20)
+  if (NOT DEFINED MS_STANDARD)
+    if (DEFINED CMAKE_CXX_STANDARD)
+      set(MS_STANDARD ${CMAKE_CXX_STANDARD})
+    else ()
+      modules_get_latest_cxx_std(MS_STANDARD)
+    endif ()
+  endif ()
+
+  if (MS_STANDARD GREATER_EQUAL 20)
 
     # Create a simple module file.
     set(temp_filepath "${CMAKE_BINARY_DIR}/module_test.cc")
@@ -99,7 +108,7 @@ function(modules_supported result)
       compilation_result "${CMAKE_BINARY_DIR}"
       SOURCES "${temp_filepath}"
       COMPILE_DEFINITIONS "${compiler_flags}"
-      CXX_STANDARD ${latest_standard}
+      CXX_STANDARD ${MS_STANDARD}
       CXX_STANDARD_REQUIRED ON
       OUTPUT_VARIABLE output)
 


### PR DESCRIPTION
Normally, when we have `CMAKE_CXX_STANDARD` defined in the current scope, user wants to compile the library using the specified standard version, so let's follow user's wishes.

This does not affect the situation when the user calls `add_module_library()` with `IF TRUE`, in this case C++20 will be forced anyway. 

## Changes
* `modules_supported()`: add ability to check modules support for specific C++ standard
* `add_module_library()`: pass `CMAKE_CXX_STANDARD` to the `modules_supported()`
* demo: improve output
```
-- C++ target standard  = 14
--     modules support  = FALSE
-- 
-- C++ latest standard  = 23
--     modules support  = TRUE
```