### PR TITLE
GCC: add -x c++ compiler flag for the module files

### DIFF
--- a/modules.cmake
+++ b/modules.cmake
@@ -192,6 +192,15 @@ function(add_module_library name)
 
   target_sources(${name} PRIVATE ${sources})
 
+  if (CMAKE_COMPILER_IS_GNUCXX)
+    # treat modules files as c++
+    foreach (src ${sources})
+      if (src MATCHES "\\.(ccm|cxxm|c\\+\\+m|cppm)$")
+        set_source_files_properties(${src} PROPERTIES COMPILE_FLAGS "-x c++")
+      endif ()
+    endforeach ()
+  endif ()
+
   if (MSVC)
     foreach (src ${sources})
       # Compile file as a module interface.


### PR DESCRIPTION
In other case files with `*.cppm` and other similar extensions will be ignored. 
Matches the behavior of CMake 3.27 https://cmake.org/cmake/help/git-master/release/dev/cxx-module-extensions.html

The proper way to set the language is to use `LANGUAGE` source file property, but in our case it requires `CMP0119 NEW` which is CMake 3.20+, but this project has CMake 3.11 as a target

Fixes https://github.com/vitaut/modules/pull/9#issuecomment-1517100156