### PR TITLE
added PTHREAD option to add_module_library

### DIFF
--- a/modules.cmake
+++ b/modules.cmake
@@ -127,9 +127,11 @@ endfunction()
 # non-modular library.
 #
 # Usage:
-#   add_module_library(<name> [sources...] FALLBACK [sources...] [IF enabled])
+# GH: ADDED PTHREAD TO THE HELP LINE
+#   add_module_library(<name> [sources...] FALLBACK [sources...] [IF enabled] PTHREAD)
 function(add_module_library name)
-  cmake_parse_arguments(AML "" "IF" "FALLBACK" ${ARGN})
+# GH: ADDED PTHREAD TO THE <options> ITEM
+  cmake_parse_arguments(AML "PTHREAD" "IF" "FALLBACK" ${ARGN})
   set(sources ${AML_UNPARSED_ARGUMENTS})
 
   add_library(${name})
@@ -146,6 +148,16 @@ function(add_module_library name)
     target_sources(${name} PRIVATE ${AML_FALLBACK})
     return()
   endif ()
+
+# GH: CODE ADDED FROM HERE TO GH: END OF CODE SECTION
+  if(AML_PTHREAD STREQUAL TRUE)
+    if(NOT MSVC)
+      set(PTHREAD_FLAG -pthread)
+    endif()
+  else()
+      set(PTHREAD_FLAG "")
+  endif()
+# GH: END OF CODE SECTION
 
   # Modules require C++20.
   target_compile_features(${name} PUBLIC cxx_std_20)
@@ -177,6 +189,8 @@ function(add_module_library name)
       add_custom_command(
         OUTPUT ${pcm}
         COMMAND ${CMAKE_CXX_COMPILER}
+# GH: ADDED FOLLOWING LINE
+                ${PTHREAD_FLAG}
                 -std=c++${std} -x c++-module --precompile -c
                 -o ${pcm} ${CMAKE_CURRENT_SOURCE_DIR}/${src}
                 "$<$<BOOL:${prop}>:-I$<JOIN:${prop},;-I>>"


### PR DESCRIPTION
I tried your suggested fix for adding the -pthread flag ([#17](https://github.com/vitaut/modules/issues/17))  but I could not get it to work, hence this PR.

I simply add an <option> to the function call and if the PTHREAD option is given, sets a variable to "-pthread" (if not MSVC) and uses that variable in the compile step.

This is my first ever PR, so please excuse me for any protocol missteps.