### PR TITLE
modules.cmake: Expand compile options generator expression

### DIFF
--- a/modules.cmake
+++ b/modules.cmake
@@ -196,6 +196,8 @@ function(add_module_library name)
         OUTPUT ${obj}
         COMMAND ${CMAKE_CXX_COMPILER} $<TARGET_PROPERTY:${name},COMPILE_OPTIONS>
                 -c -o ${obj} ${pcm}
+        # Required by the generator expression above.
+        COMMAND_EXPAND_LISTS
         DEPENDS ${pcm})
     endforeach ()
   endif ()


### PR DESCRIPTION
This fixes a bug that manifests itself when interface libraries are used. For example, if we add the following three lines to the `CMakeLists.txt` in the `examples` directory, the project no longer compiles:
```cmake
add_library(options INTERFACE)
target_compile_options(options INTERFACE -Wall -Wextra)
target_link_libraries(hello PRIVATE options)
```

The reason for this is that the generator expression that contains the compile options in the second custom command in the `add_module_library` function isn’t being expanded:
```cmake
add_custom_command(
        OUTPUT ${obj}
        COMMAND ${CMAKE_CXX_COMPILER} $<TARGET_PROPERTY:${name},COMPILE_OPTIONS>
                -c -o ${obj} ${pcm}
        DEPENDS ${pcm})
```        

This leads to a bug where the generated build script contains the compile options concatenated as a CMake list, separated by `;`, which naturally causes the shell to error and compilation to fail:
```make
hello.o: hello.pcm
	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --blue --bold --progress-dir=/tmp/test2/modules/example/out/CMakeFiles --progress-num=$(CMAKE_PROGRESS_2) "Generating hello.o"
	/usr/lib64/ccache/clang++ -fmodule-file=/tmp/test2/modules/example/out/hello.pcm;-Wall;-Wextra -c -o hello.o /tmp/test2/modules/example/out/hello.pcm
```

This pr fixes that by adding `COMMAND_EXPAND_LISTS` to the custom command, which is also already used by the first custom command in the function.