### PR TITLE
Support GCC C++20+ modules.

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -14,8 +14,13 @@ message(STATUS "")
 message(STATUS "C++ latest standard  = ${std_latest_ver}")
 message(STATUS "    modules support  = ${cxx_modules_latest}")
 
+set(MAPPER_FILE ${CMAKE_BINARY_DIR}/mapper.txt)
+
 # Module library
-add_module_library(hello hello.cc FALLBACK hello_fallback.cc)
+add_module_library(NAME hello
+  MAPPER_FILE ${MAPPER_FILE}
+  SOURCES ${CMAKE_CURRENT_LIST_DIR}/hello.cc
+  SOURCES_FALLBACK ${CMAKE_CURRENT_LIST_DIR/}hello_fallback.cc)
 target_include_directories(hello PUBLIC include)
 
 # Demo application
@@ -26,3 +31,8 @@ else()
 endif()
 add_executable(main ${app_src})
 target_link_libraries(main hello)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+  target_compile_options(main PUBLIC
+    -fmodule-mapper=${MAPPER_FILE})
+endif ()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -17,10 +17,7 @@ message(STATUS "    modules support  = ${cxx_modules_latest}")
 set(MAPPER_FILE ${CMAKE_BINARY_DIR}/mapper.txt)
 
 # Module library
-add_module_library(NAME hello
-  MAPPER_FILE ${MAPPER_FILE}
-  SOURCES ${CMAKE_CURRENT_LIST_DIR}/hello.cc
-  SOURCES_FALLBACK ${CMAKE_CURRENT_LIST_DIR/}hello_fallback.cc)
+add_module_library(hello hello.cc FALLBACK hello_fallback.cc MAPPER_FILE ${MAPPER_FILE})
 target_include_directories(hello PUBLIC include)
 
 # Demo application
@@ -31,8 +28,3 @@ else()
 endif()
 add_executable(main ${app_src})
 target_link_libraries(main hello)
-
-if(CMAKE_COMPILER_IS_GNUCXX)
-  target_compile_options(main PUBLIC
-    -fmodule-mapper=${MAPPER_FILE})
-endif ()

--- a/mapper.cmake
+++ b/mapper.cmake
@@ -1,0 +1,8 @@
+write_file(${MAPPER_FILE} "")
+FILE(GLOB children RELATIVE ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/ ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/*)
+FOREACH(child ${children})
+  IF(NOT (IS_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/${child}))
+    get_filename_component(inc ${child} NAME_WE)
+    write_file(${MAPPER_FILE} ${inc} " " ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/${child} "\n" )
+  ENDIF()
+ENDFOREACH()

--- a/mapper.cmake
+++ b/mapper.cmake
@@ -1,8 +1,15 @@
-write_file(${MAPPER_FILE} "") # TODO: merge all libs files
+if(NOT(EXISTS ${MAPPER_FILE}))
+  # create file if doesn't exist
+  write_file(${MAPPER_FILE} "") 
+endif()
 FILE(GLOB children RELATIVE ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/ ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/*)
 FOREACH(child ${children})
   IF(NOT (IS_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/${child}))
+    # remove module from mapper file if exists, then append new module to mapper file
     get_filename_component(inc ${child} NAME_WE)
-    write_file(${MAPPER_FILE} ${inc} " " ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/${child} "\n" )
+    file(READ ${MAPPER_FILE} file_data)
+    string(REGEX REPLACE "[ \t]*${inc}[ \t]+[^\n]+\n" "" file_data ${file_data})
+    set(file_data "${file_data}\n${inc} ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/${child}\n")
+    file(WRITE ${MAPPER_FILE} "${file_data}")
   ENDIF()
 ENDFOREACH()

--- a/mapper.cmake
+++ b/mapper.cmake
@@ -1,4 +1,4 @@
-write_file(${MAPPER_FILE} "")
+write_file(${MAPPER_FILE} "") # TODO: merge all libs files
 FILE(GLOB children RELATIVE ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/ ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/*)
 FOREACH(child ${children})
   IF(NOT (IS_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gcm.cache/${child}))

--- a/modules.cmake
+++ b/modules.cmake
@@ -241,7 +241,7 @@ function(add_module_library name)
       COMMAND_EXPAND_LISTS
       DEPENDS ${gcms})
 
-    SET_SOURCE_FILES_PROPERTIES(
+    set_source_files_properties(
       ${sources} PROPERTIES OBJECT_DEPENDS ${mapper_file})
   endif ()
 

--- a/modules.cmake
+++ b/modules.cmake
@@ -37,7 +37,7 @@
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
     set(CMAKE_CXX_EXTENSIONS OFF)
-  elseif (CMAKE_CXX_EXTENSIONS)
+  elseif (NOT CMAKE_CXX_EXTENSIONS)
     message(
       WARNING
       "Clang requires CMAKE_CXX_EXTENSIONS to be set to false to use modules.")
@@ -131,24 +131,28 @@ endfunction()
 function(add_module_library)
   cmake_parse_arguments(
         ADD_MODULE_LIBRARY # prefix of output variables
-        "FALLBACK" # list of names of the boolean arguments (only defined ones will be true)
-        "NAME;MAPPER_FILE" # list of names of mono-valued arguments
+        "" # list of names of the boolean arguments (only defined ones will be true)
+        "FALLBACK;NAME;MAPPER_FILE" # list of names of mono-valued arguments
         "SOURCES;SOURCES_FALLBACK" # list of names of multi-valued arguments (output variables are lists)
         ${ARGN} # arguments of the function to parse, here we take the all original ones
     )
 
   set(name ${ADD_MODULE_LIBRARY_NAME})
   set(mapper_file ${ADD_MODULE_LIBRARY_MAPPER_FILE})
-  set(FALLBACK ${ADD_MODULE_LIBRARY_FALLBACK})
-  set(fallback_sources ${ADD_MODULE_LIBRARY_FALLBACK_SOURCES})
+  set(fallback_sources ${ADD_MODULE_LIBRARY_SOURCES_FALLBACK})
   set(sources ${ADD_MODULE_LIBRARY_SOURCES})
 
   add_library(${name})
   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
 
+  # Detect module support in case it was not explicitly defined
+  if(NOT DEFINED ADD_MODULE_LIBRARY_FALLBACK)
+    modules_supported(ADD_MODULE_LIBRARY_FALLBACK)
+  endif()
+
   # Add fallback sources to the target in case modules are not supported or
   # fallback was explicitly selected.
-  if (FALLBACK)
+  if (NOT ${ADD_MODULE_LIBRARY_FALLBACK})
     target_sources(${name} PRIVATE ${fallback_sources})
     return()
   endif ()


### PR DESCRIPTION
This PR does the following:
- Used mapper.txt to expose `.gcm` location to top/down files, example:
  - `mapper.txt` content: `hello /abs./path/to//modules/example/build/gcm.cache/hello.gcm`
  - compile main with: `-fmodule-mapper=/abs./path/to/mapper.txt`
- Added `cmake_parse_arguments` as it handle arguments better.

NOTE:
- I haven't tried system modules, maybe some modifications will be needed!
- Tested with gcc-13.1.0 and clang-17.0.0

