### PR TITLE
Fix wrong condition for warning CMAKE_CXX_EXTENSION

### DIFF
--- a/modules.cmake
+++ b/modules.cmake
@@ -37,7 +37,7 @@
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
     set(CMAKE_CXX_EXTENSIONS OFF)
-  elseif (NOT CMAKE_CXX_EXTENSIONS)
+  elseif (CMAKE_CXX_EXTENSIONS)
     message(
       WARNING
       "Clang requires CMAKE_CXX_EXTENSIONS to be set to false to use modules.")


### PR DESCRIPTION
Fixes the wrong condition that warns the opposite:
https://github.com/vitaut/modules/blob/963f66e34935bebf49a69bb5496f2775e7a75f46/modules.cmake#L34-L45