### PR TITLE
Use built-in CMake support when CMake >= 3.28

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.11...3.28)
 project(HELLO CXX)
 
 # Include module library

--- a/modules.cmake
+++ b/modules.cmake
@@ -153,7 +153,7 @@ function(add_module_library name)
     target_compile_options(${name} PUBLIC -fmodules-ts)
   endif ()
 
-  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_VERSION VERSION_LESS 3.28)
     # `std` is affected by CMake options and may be higher than C++20.
     # Clang does not support c++23/c++26 names, so replace it with 2b.
     get_target_property(std ${name} CXX_STANDARD)
@@ -203,9 +203,13 @@ function(add_module_library name)
     endforeach ()
   endif ()
 
-  target_sources(${name} PRIVATE ${sources})
+  if(CMAKE_VERSION VERSION_LESS 3.28)
+    target_sources(${name} PRIVATE ${sources})
+  else()
+    target_sources(${name} PUBLIC FILE_SET fmt_module TYPE CXX_MODULES FILES ${sources})
+  endif()
 
-  if (MSVC)
+  if (MSVC AND CMAKE_VERSION VERSION_LESS 3.28)
     foreach (src ${sources})
       # Compile file as a module interface.
       set_source_files_properties(${src} PROPERTIES COMPILE_FLAGS /interface)


### PR DESCRIPTION
CMake 3.28 enables support for module handling using dependency scanning (when using a supported compiler and generator): https://cmake.org/cmake/help/latest/release/3.28.html

Note that for dependency scanning to be enabled automatically, the policy level needs to be 3.28 or higher. Wonder if it's worth setting that from here or not (or at least an error/warning if it isn't).
